### PR TITLE
Changing writeTexture validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4718,9 +4718,10 @@ GPUQueue includes GPUObjectBase;
                     - If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - |destination|.{{GPUTextureCopyView/texture}} is [=valid=].
+                            - [$validating GPUTextureCopyView$](|destination|) returns true.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
+                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
                             - [$validating linear texture data$](|dataLayout|,
                                 |data|.byteLength,
                                 |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},


### PR DESCRIPTION
These are changes in validation of writeTexture to make it match validation of copyBufferToTexture.

We should validate the whole texture copy view instead of only the texture inside it and also check the sampleCount of the texture.